### PR TITLE
fix powerhook example code

### DIFF
--- a/_posts/ios/2014-05-09-power-hooks.md
+++ b/_posts/ios/2014-05-09-power-hooks.md
@@ -96,7 +96,8 @@ This declaration should occur in the **didFinishLaunchingWithOptions:** method i
                            friendlyName:@"discount popup"
                                    data:@{ @"shouldDisplayAlert" : @"NO",
                                            @"name" : @"value1",
-                                           @"discountAmount" : @"value2"
+                                           @"discountAmount" : @"value2",
+                                           @"product" : @"value3"
                                          }
                                andBlock:^(NSDictionary *data, id context) {
 


### PR DESCRIPTION
previous example code did not include a parameter for "product", but referenced it in the code block.