### PR TITLE
Removing Hubspot link

### DIFF
--- a/user-guide/index.html
+++ b/user-guide/index.html
@@ -13,8 +13,8 @@ description: "Getting started with the Artisan MEM platform."
 
 <ul>
 	<li><a href="http://useartisan.com/pricing/" target="_blank">Purchase a subscription</a></li>
-	<li><a href="http://info.useartisan.com/platform-sign-up" target="_blank">Start a free 30-day trial</a></li>
-	<li><a href="http://info.useartisan.com/platform-sign-up" target="_blank">Use the platform for free</a> (under 10,000 MAU)</li>
+	<li><a href="http://useartisan.com/contact/" target="_blank">Start a free 30-day trial</a></li>
+	<li><a href="http://useartisan.com/contact/" target="_blank">Use the platform for free</a> (under 10,000 MAU)</li>
 </ul>
 
 <h2>Inviting Team Members</h2>


### PR DESCRIPTION
Updating sign-up link to point to our website instead of HubSpot.